### PR TITLE
Remove dynamic dispatch for SudokuRenderer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@ use sudoku::{SudokuBoard, SudokuError, SudokuField};
 // then placing the number in the field. After this we will recurse by calling
 // the same function once again, but below the recursion we will put back None
 // into the field, so if the program backtracks, it will restore the original state.
-pub fn solve_board(
+pub fn solve_board<T: SudokuRenderer>(
     board: &mut SudokuBoard,
-    renderer: &dyn SudokuRenderer,
+    renderer: &T,
 ) -> Result<SudokuBoard, SudokuError> {
     // Render the current board
     renderer.display_step(board);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::{crate_version, App, AppSettings, Arg};
 use fabrik::{renderers::SudokuRenderer, solve_board, sudoku::SudokuBoard};
 use std::{convert::TryFrom, fs};
 
-use crate::terminal_renderers::{DelayedRenderer, TerminalRenderer};
+use crate::terminal_renderers::{DelayedRenderer, Renderer, TerminalRenderer};
 
 fn main() {
     let matches = App::new("fabrik")
@@ -27,16 +27,17 @@ fn main() {
         .get_matches();
 
     let filename = matches.value_of("INPUT").unwrap();
-    let renderer: &dyn SudokuRenderer = if matches.is_present("display") {
-        &DelayedRenderer {}
+
+    let renderer: Renderer = if matches.is_present("display") {
+        Renderer::Delayed(DelayedRenderer {})
     } else {
-        &TerminalRenderer {}
+        Renderer::FinalResultOnly(TerminalRenderer {})
     };
 
     // Set up renderer
     renderer.setup(filename);
 
-    match solve(filename, renderer) {
+    match solve(filename, &renderer) {
         Ok(board) => {
             renderer.display_final_result(&board);
             renderer.teardown();
@@ -51,9 +52,9 @@ fn main() {
 }
 
 // Solve the sudoku given an optional callback
-fn solve(
+fn solve<T: SudokuRenderer>(
     filename: &str,
-    renderer: &dyn SudokuRenderer,
+    renderer: &T,
 ) -> Result<SudokuBoard, Box<dyn std::error::Error>> {
     let sudoku_file = fs::read_to_string(filename)?;
     let mut board = SudokuBoard::try_from(sudoku_file)?;

--- a/src/terminal_renderers/mod.rs
+++ b/src/terminal_renderers/mod.rs
@@ -1,6 +1,8 @@
 mod ansi;
 mod delayed_renderer;
+mod renderer;
 mod terminal_renderer;
 
 pub use delayed_renderer::DelayedRenderer;
+pub use renderer::Renderer;
 pub use terminal_renderer::TerminalRenderer;

--- a/src/terminal_renderers/renderer.rs
+++ b/src/terminal_renderers/renderer.rs
@@ -1,0 +1,43 @@
+//// The Renderer is an enum allowing main.rs to build a renderer and pass it to the `solve`
+//// functions. It contains the options for rendering sudokus in the `bin` crate. It implements
+//// SudokuRenderer so it can be passed into a function with those trait bounds, and it just
+//// delegates to the internal renderers.
+
+use fabrik::{renderers::SudokuRenderer, sudoku::SudokuBoard};
+
+use super::{DelayedRenderer, TerminalRenderer};
+
+pub enum Renderer {
+    Delayed(DelayedRenderer),
+    FinalResultOnly(TerminalRenderer),
+}
+
+impl SudokuRenderer for Renderer {
+    fn setup(&self, filename: &str) {
+        match self {
+            Renderer::Delayed(renderer) => renderer.setup(filename),
+            Renderer::FinalResultOnly(renderer) => renderer.setup(filename),
+        }
+    }
+
+    fn display_step(&self, board: &SudokuBoard) {
+        match self {
+            Renderer::Delayed(renderer) => renderer.display_step(board),
+            Renderer::FinalResultOnly(renderer) => renderer.display_step(board),
+        }
+    }
+
+    fn display_final_result(&self, board: &SudokuBoard) {
+        match self {
+            Renderer::Delayed(renderer) => renderer.display_final_result(board),
+            Renderer::FinalResultOnly(renderer) => renderer.display_final_result(board),
+        }
+    }
+
+    fn teardown(&self) {
+        match self {
+            Renderer::Delayed(renderer) => renderer.teardown(),
+            Renderer::FinalResultOnly(renderer) => renderer.teardown(),
+        }
+    }
+}


### PR DESCRIPTION
This removes the dynamic dispatch for SudokuRenderer by use a `Renderer` Enum in main crate and by changing the `solve` functions to be generic over `T: SudokuRenderer`

The `Renderer` Enum implements `SudokuRenderer`, and delegates to the concrete implementation underneath. This enables the `bin` crate to have several different renderers.

Figured out how to do it after discussing it in the thread https://www.reddit.com/r/rust/comments/pi9sea/cannot_infer_type_for_closure_reference_wrapped - thanks esitsu 👍 