### PR TITLE
Reimplement --delay flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ Put a sudoku in a file, with empty fields as `-` and `1-9` as field values. For 
 If the file is called `sudoku-1.txt`, solve it using `fabrik <filename>`. If you pass the `--display` or `-d` flag, the sudoku will be solved with a delay after each step. This is great for learning how backtracking works.
 
 ```
-# use --display as flag if you want to see the solving step by step
+# Solve a sudoku in display mode
+$ fabrik sudoku-1.txt --display
+
+# Solve a sudoku in display with custom delay (1ms per step)
+$ fabrik sudoku-1.txt --display --delay 1
+
+# Solve a sudoku and display the final result
 $ fabrik sudoku-1.txt
 +-----------+
 |632|514|987|

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 mod terminal_renderers;
 
+use crate::terminal_renderers::{DelayedRenderer, Renderer, TerminalRenderer};
 use clap::{crate_version, App, AppSettings, Arg};
 use fabrik::{renderers::SudokuRenderer, solve_board, sudoku::SudokuBoard};
-use std::{convert::TryFrom, fs};
-
-use crate::terminal_renderers::{DelayedRenderer, Renderer, TerminalRenderer};
+use std::{convert::TryFrom, fs, time::Duration};
 
 fn main() {
     let matches = App::new("fabrik")
@@ -16,6 +15,12 @@ fn main() {
                 .long("display")
                 .short('d')
                 .about("Solve the sudoku in display mode"),
+        )
+        .arg(
+            Arg::new("delay")
+                .long("delay")
+                .takes_value(true)
+                .about("Set the delay in ms used in display mode (defaults to 50ms)"),
         )
         .setting(AppSettings::ArgRequiredElseHelp)
         .arg(
@@ -29,7 +34,13 @@ fn main() {
     let filename = matches.value_of("INPUT").unwrap();
 
     let renderer: Renderer = if matches.is_present("display") {
-        Renderer::Delayed(DelayedRenderer {})
+        let delay = matches
+            .value_of("delay")
+            .map_or(50, |x| x.parse().unwrap_or(50));
+
+        let delay = Duration::from_millis(delay);
+
+        Renderer::Delayed(DelayedRenderer { delay })
     } else {
         Renderer::FinalResultOnly(TerminalRenderer {})
     };

--- a/src/terminal_renderers/delayed_renderer.rs
+++ b/src/terminal_renderers/delayed_renderer.rs
@@ -1,25 +1,25 @@
 use fabrik::{renderers::SudokuRenderer, sudoku::SudokuBoard};
-use std::{thread, time};
+use std::{thread, time::Duration};
 
 use crate::terminal_renderers::ansi::*;
 
-const SLEEP_TIME: time::Duration = time::Duration::from_millis(50);
-
-pub struct DelayedRenderer {}
+pub struct DelayedRenderer {
+    pub delay: Duration,
+}
 
 impl SudokuRenderer for DelayedRenderer {
     fn setup(&self, filename: &str) {
         clear_screen();
         hide_cursor();
         cursor_at_position(1, 1);
-        println!("Solving {} with 50ms step delay", filename);
+        println!("Solving {} with {:?} step delay", filename, self.delay);
     }
 
     // Display the result after a single step
     fn display_step(&self, board: &SudokuBoard) {
         cursor_at_position(3, 1);
         print!("{}", board);
-        thread::sleep(SLEEP_TIME);
+        thread::sleep(self.delay);
     }
 
     // Since the delayed renderer will end up with a solved sudoku using display_step,


### PR DESCRIPTION
This PR reimplements the  `--delay` flag that can be used in display mode. The reintroduction happens through the `DelayedRenderer` struct.