### PR TITLE
Create a board iterator

### DIFF
--- a/src/sudoku/iter/board_iter.rs
+++ b/src/sudoku/iter/board_iter.rs
@@ -1,0 +1,80 @@
+use crate::sudoku::{Position, SudokuBoard, SudokuField};
+
+/// Iterator that emits a tuple of (Position, SudokuField).
+/// The current position of the iterator will be the next value emitted.
+pub struct BoardIter<'a> {
+    board: &'a SudokuBoard,
+    position: Position,
+}
+
+impl BoardIter<'_> {
+    pub fn new(board: &SudokuBoard, position: Position) -> BoardIter {
+        BoardIter { board, position }
+    }
+}
+
+impl Iterator for BoardIter<'_> {
+    type Item = (Position, SudokuField);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.position.is_valid() {
+            let value = *self.board.get_field(&self.position);
+            let position = self.position;
+            self.position = self.position.increment();
+
+            return Some((position, value));
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+
+    use super::*;
+
+    const TEST_SUDOKU: &str = "
+            -47---96-\n
+            8--716--2\n
+            6-------8\n
+            --21-85--\n
+            ----9----\n
+            --16-23--\n
+            5-------1\n
+            7--945--3\n
+            -69---75-";
+
+    #[test]
+    fn iterator_with_position_emits_fields_in_expected_order() {
+        let board = SudokuBoard::try_from(TEST_SUDOKU.to_string()).unwrap();
+        let mut iterator = BoardIter {
+            board: &board,
+            position: Position { row: 0, column: 0 },
+        };
+
+        for &value in &[
+            (Position { row: 0, column: 0 }, SudokuField::Empty),
+            (Position { row: 0, column: 1 }, SudokuField::Value(4)),
+            (Position { row: 0, column: 2 }, SudokuField::Value(7)),
+            (Position { row: 0, column: 3 }, SudokuField::Empty),
+        ] {
+            assert_eq!(iterator.next(), Some(value));
+        }
+
+        // Advance 75 fields
+        for _val in 0..75 {
+            iterator.next();
+        }
+
+        for &value in &[
+            (Position { row: 8, column: 7 }, SudokuField::Value(5)),
+            (Position { row: 8, column: 8 }, SudokuField::Empty),
+        ] {
+            assert_eq!(iterator.next(), Some(value));
+        }
+
+        assert!(iterator.next().is_none());
+    }
+}

--- a/src/sudoku/iter/mod.rs
+++ b/src/sudoku/iter/mod.rs
@@ -1,0 +1,3 @@
+mod board_iter;
+
+pub use board_iter::*;

--- a/src/sudoku/mod.rs
+++ b/src/sudoku/mod.rs
@@ -1,3 +1,4 @@
+mod iter;
 mod position;
 mod sudoku_board;
 mod sudoku_error;

--- a/src/sudoku/position.rs
+++ b/src/sudoku/position.rs
@@ -4,6 +4,16 @@ pub struct Position {
     pub column: usize,
 }
 
+impl From<usize> for Position {
+    /// Convert a 1d usize into a position
+    fn from(coords: usize) -> Self {
+        Position {
+            row: coords / 9,
+            column: coords % 9,
+        }
+    }
+}
+
 impl From<(usize, usize)> for Position {
     /// Convert a 2d usize of (row, col) into a position
     fn from(coords: (usize, usize)) -> Self {
@@ -11,5 +21,17 @@ impl From<(usize, usize)> for Position {
             row: coords.0,
             column: coords.1,
         }
+    }
+}
+
+impl Position {
+    pub fn increment(&self) -> Position {
+        let new_position = self.row * 9 + self.column + 1;
+
+        Position::from(new_position)
+    }
+
+    pub fn is_valid(&self) -> bool {
+        (0..=8).contains(&self.row) && (0..=8).contains(&self.column)
     }
 }

--- a/src/sudoku/sudoku_board.rs
+++ b/src/sudoku/sudoku_board.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryFrom, fmt::Display};
 
-use super::{position::Position, SudokuError, SudokuField};
+use super::{iter::BoardIter, position::Position, SudokuError, SudokuField};
 
 #[derive(Clone)]
 pub struct SudokuBoard([[SudokuField; 9]; 9]);
@@ -18,25 +18,9 @@ impl SudokuBoard {
 
     /// Get the first free field of the board as (row, column)
     pub fn next_empty_field(&self, position: &Position) -> Option<Position> {
-        for row in position.row..9 {
-            if row == position.row {
-                for column in position.column..9 {
-                    let position = Position { row, column };
-                    if self.get_field(&position).is_empty() {
-                        return Some(position);
-                    }
-                }
-            } else {
-                for column in 0..9 {
-                    let position = Position { row, column };
-                    if self.get_field(&position).is_empty() {
-                        return Some(position);
-                    }
-                }
-            }
-        }
-
-        None
+        BoardIter::new(self, *position)
+            .find(|(_position, field)| field.is_empty())
+            .map(|(position, _field)| position)
     }
 
     /// Is a number valid at a given position?

--- a/src/sudoku/sudoku_board.rs
+++ b/src/sudoku/sudoku_board.rs
@@ -16,7 +16,7 @@ impl SudokuBoard {
         self.0[position.row][position.column] = sudoku_field;
     }
 
-    /// Get the first free field of the board as (row, column)
+    /// Get the next free field of the board
     pub fn next_empty_field(&self, position: &Position) -> Option<Position> {
         BoardIter::new(self, *position)
             .find(|(_position, field)| field.is_empty())


### PR DESCRIPTION
This makes it possible to search the board from a given `Position` and forward using iterators.

Are there some speed improvements I'm missing?

My questions:
- Is the iterator emitting references to `Position` and to `SudokuField` (as `Iter` is supposed to)?
- Would it be faster if it did emit references?
- I am using `BoardIter::new(self, *position)` in `sudoku_board.rs:21`. Would it be better to use `self.into_iter()`? (However, I need to send along `position` too, so I would need another struct to hold both Board and Position, and then call `.into_iter()` on that, as I understand it)