### PR TITLE
Speedup: Use the custom stack less

### DIFF
--- a/src/backtracking_iter.rs
+++ b/src/backtracking_iter.rs
@@ -54,18 +54,19 @@ impl BacktrackingIter {
                     Instruction::TryValue(pos, v) => {
                         self.current_position = pos;
 
-                        // Insert TryValue(v + 1) on the top of the stack, to be able to resume work on this field
-                        // if we backtrack to this position again. But only if (v + 1 <= 9).
-                        if v < 9 {
-                            self.stack.push(Instruction::TryValue(pos, v + 1));
-                        }
+                        for value in v..=9 {
+                            let field = Field::from_u8(value);
 
-                        let field = Field::from_u8(v);
+                            if self.board.valid_number_at_position(pos, &field) {
+                                // Insert TryValue(v + 1) on the top of the stack, to be able to resume work on this field
+                                // if we backtrack to this position again. But only if (v + 1 <= 9).
+                                if value < 9 {
+                                    self.stack.push(Instruction::TryValue(pos, value + 1));
+                                }
 
-                        if self.board.valid_number_at_position(pos, &field) {
-                            self.board.put_field(pos, field);
-
-                            return WhatHappened::PutNewFieldOnBoard;
+                                self.board.put_field(pos, field);
+                                return WhatHappened::PutNewFieldOnBoard;
+                            }
                         }
 
                         // Nothing is returned, which means what we will loop once more

--- a/src/backtracking_iter.rs
+++ b/src/backtracking_iter.rs
@@ -22,7 +22,7 @@ enum WhatHappened {
 
 #[derive(Copy, Clone, Debug)]
 enum Instruction {
-    TryValue(Position, u8),
+    WorkOnField(Position, u8),
     BackTo(Position),
 }
 
@@ -43,7 +43,8 @@ impl BacktrackingIter {
 
         // Try the value 1 first. This will be incremented up until 9 during execution.
         // We could have pushed 9 separate instructions instead, but this performs better.
-        self.stack.push(Instruction::TryValue(next_empty_field, 1));
+        self.stack
+            .push(Instruction::WorkOnField(next_empty_field, 1));
     }
 
     // Manipulate the board from the stack instructions
@@ -51,17 +52,17 @@ impl BacktrackingIter {
         loop {
             match self.stack.pop() {
                 Some(instruction) => match instruction {
-                    Instruction::TryValue(pos, v) => {
+                    Instruction::WorkOnField(pos, v) => {
                         self.current_position = pos;
 
                         for value in v..=9 {
                             let field = Field::from_u8(value);
 
                             if self.board.valid_number_at_position(pos, &field) {
-                                // Insert TryValue(v + 1) on the top of the stack, to be able to resume work on this field
-                                // if we backtrack to this position again. But only if (v + 1 <= 9).
+                                // Insert WorkOnField(current_position, v + 1) on the top of the stack,
+                                // to be able to resume work on this field if we backtrack to this position again.
                                 if value < 9 {
-                                    self.stack.push(Instruction::TryValue(pos, value + 1));
+                                    self.stack.push(Instruction::WorkOnField(pos, value + 1));
                                 }
 
                                 self.board.put_field(pos, field);

--- a/src/backtracking_iter.rs
+++ b/src/backtracking_iter.rs
@@ -38,10 +38,8 @@ impl BacktrackingIter {
 
     // Prepare instructions in the stack for execution
     fn prepare_stack(&mut self, next_empty_field: Position) {
-        // Insert a BackTo(position) with the current position if there are instructions in the stack
-        if !self.stack.is_empty() {
-            self.stack.push(Instruction::BackTo(self.current_position));
-        }
+        // Insert a BackTo(position) with the current position
+        self.stack.push(Instruction::BackTo(self.current_position));
 
         // Try the value 1 first. This will be incremented up until 9 during execution.
         // We could have pushed 9 separate instructions instead, but this performs better.


### PR DESCRIPTION
Instead of pushing the next `TryValue` enum to the stack for every value, use a for-loop when working on a field until either a possible value is found, or all values are tried.

Benches consistently show around 7-9% faster speed than before and tests are green.