### PR TITLE
Simplify instructions, change enum to struct

### DIFF
--- a/src/backtracking_iter.rs
+++ b/src/backtracking_iter.rs
@@ -23,7 +23,7 @@ enum WhatHappened {
 #[derive(Copy, Clone, Debug)]
 enum Instruction {
     WorkOnField(Position, u8),
-    BackTo(Position),
+    ClearField(Position),
 }
 
 impl BacktrackingIter {
@@ -38,9 +38,6 @@ impl BacktrackingIter {
 
     // Prepare instructions in the stack for execution
     fn prepare_stack(&mut self, next_empty_field: Position) {
-        // Insert a BackTo(position) with the current position
-        self.stack.push(Instruction::BackTo(self.current_position));
-
         // Try the value 1 first. This will be incremented up until 9 during execution.
         // We could have pushed 9 separate instructions instead, but this performs better.
         self.stack
@@ -63,6 +60,8 @@ impl BacktrackingIter {
                                 // to be able to resume work on this field if we backtrack to this position again.
                                 if value < 9 {
                                     self.stack.push(Instruction::WorkOnField(pos, value + 1));
+                                } else {
+                                    self.stack.push(Instruction::ClearField(pos))
                                 }
 
                                 self.board.put_field(pos, field);
@@ -70,14 +69,10 @@ impl BacktrackingIter {
                             }
                         }
 
-                        // Nothing is returned, which means what we will loop once more
+                        self.board.put_field(pos, Field::empty());
                     }
-                    Instruction::BackTo(pos) => {
-                        // Clear out the current position before moving back
-                        self.board.put_field(self.current_position, Field::empty());
-
-                        // Move back
-                        self.current_position = pos;
+                    Instruction::ClearField(pos) => {
+                        self.board.put_field(pos, Field::empty());
                     }
                 },
                 None => {

--- a/src/backtracking_iter.rs
+++ b/src/backtracking_iter.rs
@@ -49,7 +49,9 @@ impl BacktrackingIter {
                         self.current_position = pos;
 
                         for value in v..=10 {
-                            if let Ok(field) = Field::new(value) {
+                            if value <= 9 {
+                                let field = Field::from_u8(value);
+
                                 if self.board.valid_number_at_position(pos, &field) {
                                     // Insert WorkOnField(current_position, v + 1) on the top of the stack,
                                     // to be able to resume work on this field if we backtrack to this position again.
@@ -58,7 +60,11 @@ impl BacktrackingIter {
                                     self.board.put_field(pos, field);
                                     return WhatHappened::PutNewFieldOnBoard;
                                 }
+
+                                // If nothing is returned, we will simply run the for-loop again.
                             } else {
+                                // We have tried all number 1..9 for this field. Clear it and loop in the outer loop,
+                                // effectively backtracking to the previous position.
                                 self.board.put_field(pos, Field::empty());
                             }
                         }

--- a/src/backtracking_iter.rs
+++ b/src/backtracking_iter.rs
@@ -12,7 +12,7 @@ use super::{field::Field, position::Position};
 pub struct BacktrackingIter {
     board: Board,
     current_position: Position,
-    stack: Vec<Instruction>,
+    stack: Vec<WorkOnField>,
 }
 
 enum WhatHappened {
@@ -21,9 +21,7 @@ enum WhatHappened {
 }
 
 #[derive(Copy, Clone, Debug)]
-enum Instruction {
-    WorkOnField(Position, u8),
-}
+struct WorkOnField(Position, u8);
 
 impl BacktrackingIter {
     /// Create a backtracking iterator for a Board
@@ -39,8 +37,7 @@ impl BacktrackingIter {
     fn prepare_stack(&mut self, next_empty_field: Position) {
         // Try the value 1 first. This will be incremented up until 9 during execution.
         // We could have pushed 9 separate instructions instead, but this performs better.
-        self.stack
-            .push(Instruction::WorkOnField(next_empty_field, 1));
+        self.stack.push(WorkOnField(next_empty_field, 1));
     }
 
     // Manipulate the board from the stack instructions
@@ -48,7 +45,7 @@ impl BacktrackingIter {
         loop {
             match self.stack.pop() {
                 Some(instruction) => match instruction {
-                    Instruction::WorkOnField(pos, v) => {
+                    WorkOnField(pos, v) => {
                         self.current_position = pos;
 
                         for value in v..=10 {
@@ -56,7 +53,7 @@ impl BacktrackingIter {
                                 if self.board.valid_number_at_position(pos, &field) {
                                     // Insert WorkOnField(current_position, v + 1) on the top of the stack,
                                     // to be able to resume work on this field if we backtrack to this position again.
-                                    self.stack.push(Instruction::WorkOnField(pos, value + 1));
+                                    self.stack.push(WorkOnField(pos, value + 1));
 
                                     self.board.put_field(pos, field);
                                     return WhatHappened::PutNewFieldOnBoard;


### PR DESCRIPTION
This changes the `Instruction` enum to be a single `WorkOnField` struct instead for simpler readability. The `BackTo` instruction was no longer necessary if the code is structured a bit differently.